### PR TITLE
remove meka from package list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 setup(
     name='scikit-multilearn',
     version='0.0.1',
-    packages=['skmultilearn','meka'],
+    packages=['skmultilearn'],
     author=u'Piotr Szymański',
     author_email='niedakh@gmail.com',
     license='BSD',


### PR DESCRIPTION
I'm not too sure about this, but `pip install --editable` does not work anymore after you've removed meka from the root level. I think this fixes it.