### PR TITLE
remove extra dependencies from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,5 @@
 liac-arff==2.1.0
-base64
-bz2
-copy
 igraph
 numpy
-pickle
-pkgutil
-random
-shlex
-shutil
-subprocess
-sys
-tempfile
-unittest
 scipy
 scikit-learn


### PR DESCRIPTION
I don't think the other dependencies are needed - most of them are already included in the standard library.
