### PR TITLE
Adding support for sparse X and y matrices to MLARAM

### DIFF
--- a/skmultilearn/neurofuzzy/MLARAMfast.py
+++ b/skmultilearn/neurofuzzy/MLARAMfast.py
@@ -168,6 +168,8 @@ class MLARAM(MLClassifierBase):
             labadd[y_i1.nonzero()] = 1
             self.neurons[winner].label += labadd
 
+        return self
+
     #@profile
     def predict(self, X):
         """Predict labels for X

--- a/skmultilearn/neurofuzzy/MLARAMfast.py
+++ b/skmultilearn/neurofuzzy/MLARAMfast.py
@@ -129,7 +129,6 @@ class MLARAM(MLClassifierBase):
             else:
                 y_i1 = y[i1]
 
-            found = 0
             if issparse(f1):
                 f1 = f1.todense()
             fc = numpy.concatenate((f1, ones - f1), ismatrix)
@@ -189,17 +188,17 @@ class MLARAM(MLClassifierBase):
         result = []
         ranks = self.predict_proba(X)
         for rank in ranks:
-            sortedRankarg = numpy.argsort(-rank)
-            diffs = -numpy.diff([rank[k] for k in sortedRankarg])
+            sorted_rank_arg = numpy.argsort(-rank)
+            diffs = -numpy.diff([rank[k] for k in sorted_rank_arg])
 
-            indcutt = numpy.where(diffs == (diffs).max())[0]
+            indcutt = numpy.where(diffs == diffs.max())[0]
             if len(indcutt.shape) == 1:
                 indcut = indcutt[0] + 1
             else:
                 indcut = indcutt[0, -1] + 1
             label = numpy.zeros(rank.shape)
 
-            label[sortedRankarg[0:indcut]] = 1
+            label[sorted_rank_arg[0:indcut]] = 1
 
             result.append(label)
 
@@ -221,7 +220,6 @@ class MLARAM(MLClassifierBase):
             :code:`(n_samples, n_labels)`
         """
         issparse = scipy.sparse.issparse
-        result = []
         if issparse(X):
             if X.getnnz() == 0:
                 return
@@ -236,9 +234,7 @@ class MLARAM(MLClassifierBase):
         if xma < 0 or xma > 1 or xmi < 0 or xmi > 1:
             X = numpy.multiply(X - xmi, 1 / (xma - xmi))
         ones = scipy.ones(X[0].shape)
-        n1s = [0] * len(self.neurons)
         allranks = []
-        neuronsactivated = []
 
         allneu = numpy.vstack([n1.vc for n1 in self.neurons])
         allneusum = allneu.sum(1) + self.alpha

--- a/skmultilearn/neurofuzzy/tests/test_mlaramfast.py
+++ b/skmultilearn/neurofuzzy/tests/test_mlaramfast.py
@@ -2,6 +2,7 @@ import unittest
 
 from skmultilearn.neurofuzzy import MLARAM
 from skmultilearn.tests.classifier_basetest import ClassifierBaseTest
+import numpy as np
 
 
 class MLARAMTest(ClassifierBaseTest):
@@ -15,6 +16,11 @@ class MLARAMTest(ClassifierBaseTest):
         classifier = MLARAM()
 
         self.assertClassifierWorksWithCV(classifier)
+
+    def test_if_works_with_sparsity(self):
+        classifier = MLARAM()
+
+        self.assertClassifierWorksWithSparsity(classifier, 'sparse')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The types of operations carried on in the fit() method do not allow for a straightforward implementation without resorting to todense() in a few places.
As such, what I wrote is not really taking advantage of sparse matrices, but at least it not longer crashes when provided with these instead of regular ones.

Note: I did *not* check the correctness of the implementation of the algorithm. The simple tests pass here, and another on one of my (sparse) datasets worked as well.