### PR TITLE
fixed dataset fetching and listing; closes #57

### DIFF
--- a/skmultilearn/dataset.py
+++ b/skmultilearn/dataset.py
@@ -100,9 +100,10 @@ def get_dataset_list():
     list
         the raw data with the format as above
     """
-    f = urllib.request.urlopen(get_download_base_url() + "data.list")
-    raw_data_list = f.read()
-    return raw_data_list
+    req = urllib.request.urlopen(get_download_base_url() + "data.list")
+    charset = req.info().get_content_charset()
+    raw_data_list = req.read()
+    return raw_data_list.decode(charset)
 
 
 def available_data_sets():


### PR DESCRIPTION
changes in how python 3 (in contrast to python 2) broke the dataset listing and fetching. this pr fixes this for both major python versions. the examples from #57 for listing all available datasets as well as fetching enron in this case, work. see: https://bugs.python.org/issue5419

test cases:
```
from skmultilearn.dataset import load_dataset
d = load_dataset('enron', 'undivided')
```
```
from skmultilearn.dataset import available_data_sets
available_data_sets()
```