### PR TITLE
Revert "Fix train/test order in iterative stratification"

### DIFF
--- a/skmultilearn/model_selection/iterative_stratification.py
+++ b/skmultilearn/model_selection/iterative_stratification.py
@@ -90,7 +90,7 @@ def iterative_train_test_split(X, y, test_size):
     """
 
     stratifier = IterativeStratification(n_splits=2, order=2, sample_distribution_per_fold=[test_size, 1.0-test_size])
-    train_indexes, test_indexes = next(stratifier.split(X, y))
+    test_indexes, train_indexes = next(stratifier.split(X, y))
 
     X_train, y_train = X[train_indexes, :], y[train_indexes, :]
     X_test, y_test = X[test_indexes, :], y[test_indexes, :]


### PR DESCRIPTION
Reverts scikit-multilearn/scikit-multilearn#125

Hi,
 
I tested this, but it seems to me that the output is now inverted.

If I run 
x_train,y_train,x_test,y_test= iterative_train_test_split(df, labels, test_size=0.2)
I get that x_train has 20% of the data and x_test 80%.