### PR TITLE
Rakel parameters

### DIFF
--- a/skmultilearn/ensemble/rakeld.py
+++ b/skmultilearn/ensemble/rakeld.py
@@ -24,6 +24,7 @@ class RakelD(MLClassifierBase):
         put under :code:`self.require_dense`
     labelset_size : int
         the desired size of each of the partitions, parameter k according to paper
+        Default is 3, according to paper it has the best results
 
 
     Attributes
@@ -81,7 +82,7 @@ class RakelD(MLClassifierBase):
 
     """
 
-    def __init__(self, base_classifier=None, labelset_size=None, base_classifier_require_dense=None):
+    def __init__(self, base_classifier=None, labelset_size=3, base_classifier_require_dense=None):
         super(RakelD, self).__init__()
 
         self.labelset_size = labelset_size

--- a/skmultilearn/ensemble/rakelo.py
+++ b/skmultilearn/ensemble/rakelo.py
@@ -22,9 +22,11 @@ class RakelO(MLClassifierBase):
         set under `self.classifier.require_dense`
     labelset_size : int
         the desired size of each of the partitions, parameter k according to paper.
+        According to paper, the best parameter is 3, so it's set as default
         Will be automatically set under `self.labelset_size`
     model_count : int
         the desired number of classifiers, parameter m according to paper.
+        According to paper, the best value for this parameter is 2M (being M the number of labels)
         Will be automatically set under :code:`self.model_count_`.
 
 
@@ -78,7 +80,7 @@ class RakelO(MLClassifierBase):
 
     """
 
-    def __init__(self, base_classifier=None, model_count=None, labelset_size=None, base_classifier_require_dense=None):
+    def __init__(self, base_classifier=None, model_count=None, labelset_size=3, base_classifier_require_dense=None):
         super(RakelO, self).__init__()
 
         self.model_count = model_count


### PR DESCRIPTION
Added default parameters to _labelset_size_ in both RakelD and RakelO. Stablished to 3 in order to the paper of the implementation of Rakel. Being 3 the value with the best results in that paper.