### PR TITLE
Fix syntax error in tutorial

### DIFF
--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -197,7 +197,7 @@
     }
    ],
    "source": [
-    "clf.classifiers"
+    "clf.classifiers_"
    ]
   },
   {
@@ -285,7 +285,7 @@
     }
    ],
    "source": [
-    "clf.classifiers"
+    "clf.classifiers_"
    ]
   },
   {


### PR DESCRIPTION
Fix #156 by fixing syntax error in the [tutorial notebook](https://github.com/scikit-multilearn/scikit-multilearn/blob/65278a469ccee56f111eea571670b5d1f4571048/docs/source/tutorial.ipynb)