### PR TITLE
Change position of *args before arguments of weka classifier

### DIFF
--- a/skmultilearn/ext/meka.py
+++ b/skmultilearn/ext/meka.py
@@ -424,7 +424,7 @@ class Meka(MLClassifierBase):
             self.meka_classifier,
         ]
         
-        command_args+=args
+        command_args += args
 
         if self.weka_classifier is not None:
             command_args += ['-W', self.weka_classifier]

--- a/skmultilearn/ext/meka.py
+++ b/skmultilearn/ext/meka.py
@@ -422,8 +422,9 @@ class Meka(MLClassifierBase):
             self.java_command,
             '-cp', '"{}*"'.format(self.meka_classpath),
             self.meka_classifier,
-            *args
         ]
+        
+        command_args+=args
 
         if self.weka_classifier is not None:
             command_args += ['-W', self.weka_classifier]

--- a/skmultilearn/ext/meka.py
+++ b/skmultilearn/ext/meka.py
@@ -422,12 +422,11 @@ class Meka(MLClassifierBase):
             self.java_command,
             '-cp', '"{}*"'.format(self.meka_classpath),
             self.meka_classifier,
+            *args
         ]
 
         if self.weka_classifier is not None:
             command_args += ['-W', self.weka_classifier]
-
-        command_args += args
 
         meka_command = " ".join(command_args)
 


### PR DESCRIPTION
When launch weka with parameters -t and -T options doesn't works correctly.