### PR TITLE
now can adding WEKA parameters

### DIFF
--- a/skmultilearn/ext/meka.py
+++ b/skmultilearn/ext/meka.py
@@ -425,10 +425,18 @@ class Meka(MLClassifierBase):
         ]
 
         if self.weka_classifier is not None:
-            command_args += ['-W', self.weka_classifier]
-
+            weka_classfier_name = self.weka_classifier.split(' ')[0]
+            weka_classfier_param = ' '.join(self.weka_classifier.split(' ')[1:])
+            command_args += ['-W', weka_classfier_name]
+            #command_args += ['-W', self.weka_classifier]
+        else:
+            weka_classfier_param = ''
+        
         command_args += args
-
+        
+        if weka_classfier_param is not '':
+            command_args += ['--', weka_classfier_param]
+            
         meka_command = " ".join(command_args)
 
         if sys.platform != 'win32':


### PR DESCRIPTION
The change will allow the wrapper to construct java command that contains both MEKA and WEKA parameters.

the below function will be able to work, which can specify SMO parameters, this leads to an error in the previous version. See also the question https://github.com/Waikato/meka/issues/63.

meka = Meka(
        meka_classifier = "meka.classifiers.multilabel.MULAN -S HOMER.BalancedClustering.3.ClassifierChain", # Binary Relevance
        weka_classifier = "weka.classifiers.functions.SMO -C 0.1", # with Naive Bayes single-label classifier
        meka_classpath = meka_classpath, #obtained via download_meka
        java_command = 'java', # path to java executable
)