### PR TITLE
Move from using requirements files to specifying requirements in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,32 +22,7 @@ follows a similar API to that of [scikit-learn](http://scikit-learn.org/).
 
 - __Builds upon giants!__ Team-up with the power of numpy and scikit. You can use scikit-learn's base classifiers as scikit-multilearn's classifiers. In addition, the two packages follow a similar API.
 
-## Dependencies
-
-In most cases you will want to follow the requirements defined in the requirements/*.txt files in the package. 
-
-### Base dependencies
-```
-scipy
-numpy
-future
-scikit-learn
-liac-arff # for loading ARFF files
-requests # for dataset module
-networkx # for networkX base community detection clusterers
-python-louvain # for networkX base community detection clusterers
-keras
-```
-
-### GPL-incurring dependencies for two clusterers
-```
-python-igraph # for igraph library based clusterers
-python-graphtool # for graphtool base clusterers
-```
-
-Note: Installing graphtool is complicated, please see: [graphtool install instructions](https://git.skewed.de/count0/graph-tool/wikis/installation-instructions)
-
-## Installation
+## Installation & Dependencies
 
 To install scikit-multilearn, simply type the following command:
 
@@ -64,6 +39,10 @@ $ git clone https://github.com/scikit-multilearn/scikit-multilearn.git
 $ cd scikit-multilearn
 $ python setup.py
 ```
+
+In most cases requirements are installed when you install using `pip install scikit-multilearn` or run `python setup.py install`. There are also optional dependencies `pip install scikit-multilearn[gpl,keras,meka]` installs the GPL-incurring igraph for for igraph library based clusterers, keras for the keras classifiers and requirements for the meka bridge respectively.
+
+Note that installing the GPL licensed graphtool, for graphtool based clusters, is complicated, and must be done manually, please see: [graphtool install instructions](https://git.skewed.de/count0/graph-tool/wikis/installation-instructions)
 
 ## Basic Usage
 

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,4 +1,0 @@
--r requirements/base.txt
--r requirements/gpl.txt
--r requirements/meka.txt
--r requirements/test.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
--r requirements/base.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,0 @@
-scipy==1.1.0
-numpy>=1.15.1
-liac-arff==2.2.1
-networkx==2.1
-python-louvain==0.11
-future>=0.16.0
-scikit_learn>=0.19.2
-requests>=2.18.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,0 @@
-pytest==3.3.1
-PyHamcrest==1.9.0
-ipython
-ipython-genutils

--- a/requirements/gpl.txt
+++ b/requirements/gpl.txt
@@ -1,3 +1,0 @@
-# python-graphtool is also a useful requirement but is not pip-installable,
-# see https://git.skewed.de/count0/graph-tool/wikis/installation-instructions
-python-igraph==0.7.1.post6

--- a/requirements/keras.txt
+++ b/requirements/keras.txt
@@ -1,2 +1,0 @@
-keras
-tensorflow

--- a/requirements/meka.txt
+++ b/requirements/meka.txt
@@ -1,1 +1,0 @@
-whichcraft==0.4.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,0 @@
-pytest==3.3.1
-PyHamcrest==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if sys.version_info[0] < 3:
 else:
     import io
 
-    with io.open('README.md', 'r', 'utf-8') as f:
+    with io.open('README.md', 'r', encoding='utf-8') as f:
         readme = f.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,34 @@ setup(
     name='scikit-multilearn',
     version='0.2.0',
     packages=find_packages(exclude=['docs', 'tests', '*.tests']),
+    install_requires=[
+        "scipy>=1.1.0",
+        "numpy>=1.15.1",
+        "liac-arff>=2.2.1",
+        "networkx>=2.1",
+        "python-louvain>=0.11",
+        "future>=0.16.0",
+        "scikit_learn>=0.19.2",
+        "requests>=2.18.4",
+    ],
+    extras_require={
+        "gpl":  [
+            "python-igraph>=0.7.1.post6",
+        ],
+        "dev":  [
+            "pytest>=3.3.1",
+            "PyHamcrest>=1.9.0",
+            "ipython",
+            "ipython-genutils",
+        ],
+        "keras": [
+            "keras",
+            "tensorflow",
+        ],
+        "meka": [
+            "whichcraft>=0.4.1",
+        ]
+    },
     author=u'Piotr Szymański',
     author_email=u'niedakh@gmail.com',
     license=u'BSD',


### PR DESCRIPTION
Usually Python library packages specifying dependencies so that pip/pipenv/poetry/conda can go and fetch them during installation. I've refactored the requirements files into the setup.py to make this a more conventional Python library package.

I have left the Travis build broken, since I'm not really sure exactly in what order things need to be installed to make it work. Any ideas on this?

(Previously: https://github.com/scikit-multilearn/scikit-multilearn/issues/163)