### PR TITLE
Documentation mistake in title

### DIFF
--- a/docs/source/api/skmultilearn.adapt.mltsvm.rst
+++ b/docs/source/api/skmultilearn.adapt.mltsvm.rst
@@ -1,4 +1,4 @@
-Multilabel k Nearest Neighbours
+Multilabel Twin Support Vector Machines
 =================================
 
 .. autoclass:: skmultilearn.adapt.MLTSVM


### PR DESCRIPTION
Checking the documentation of MLTSVM (http://scikit.ml/api/skmultilearn.adapt.mltsvm.html). I noticed that the title and the left text is wrong:

![image](https://user-images.githubusercontent.com/44138542/150333461-32fba602-5182-4f33-b416-826429db1ea3.png)
