### PR TITLE
Fixing a problem with installing the package from git

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,12 @@ import sys
 
 if sys.version_info[0] < 3:
     import codecs
-
     with codecs.open('README.md', 'r', 'utf-8') as f:
         readme = f.read()
 
 else:
     import io
-
-    with io.open('README.md', 'r', 'utf-8') as f:
+    with io.open('README.md', 'r', encoding = 'utf-8') as f:
         readme = f.read()
 
 setup(


### PR DESCRIPTION
The current version of setup.py fails when trying to install from git with pip install git+ and using python 3.9

This bug is probably because the open() function does not currently expect encoding as the third argument. This commit fixes that by passing the encoding as a keyword argument.

This should fix #246 