### PR TITLE
Bugfix MLkNN - NearestNeighbors(self.k)

### DIFF
--- a/skmultilearn/adapt/mlknn.py
+++ b/skmultilearn/adapt/mlknn.py
@@ -126,7 +126,7 @@ class MLkNN(MLClassifierBase):
         self.s = s  # Smooth parameter
         self.ignore_first_neighbours = ignore_first_neighbours
         self.n_jobs = n_jobs
-        self.knn_ = NearestNeighbors(self.k, n_jobs=self.n_jobs)
+        self.knn_ = NearestNeighbors(n_neighbors=self.k)
         self.copyable_attrs = ["k", "s", "ignore_first_neighbours", "n_jobs"]
 
     def _compute_prior(self, y):


### PR DESCRIPTION
Hello! 👋🏻

Thank you for your great work! As many people already reported, I was getting the following error on MLkNN:

```python 

from sklearn.datasets import make_multilabel_classification
from skmultilearn.adapt import MLkNN

X, y = make_multilabel_classification(n_samples=100, n_features=2, n_classes=5, n_labels=2, random_state=42)
classifier = MLkNN(k=3)
classifier.fit(X, y)
```

This comes from a previous warning from the older version of ScikitLearn. 
I fixed it by expliciting `n_neighbors=self.k` at row 129 ([here](https://github.com/scikit-multilearn/scikit-multilearn/blob/master/skmultilearn/adapt/mlknn.py)).
```python
self.knn_ = NearestNeighbors(n_neighbors=self.k)
```

I tested the same code with a more recent version of sklearn and it works!
```
scikit-learn-1.2.2
```

Example:

```python
from sklearn.datasets import make_multilabel_classification
from skmultilearn.adapt import MLkNN

X, y = make_multilabel_classification(n_samples=100, n_features=2, n_classes=5, n_labels=2, random_state=42)
X_test, _ = make_multilabel_classification(n_samples=2, n_features=2, n_classes=5, n_labels=2, random_state=42)

classifier = MLkNN(k=3)
classifier.fit(X,y)
predictions = classifier.predict(X_test)

print(predictions)
````

```cmd
  (0, 2)        1
  (1, 0)        1
  (1, 2)        1
  (1, 3)        1
```

I hope it helped! 