### PR TITLE
Fix label selection during stratification

### DIFF
--- a/skmultilearn/model_selection/iterative_stratification.py
+++ b/skmultilearn/model_selection/iterative_stratification.py
@@ -159,10 +159,11 @@ def _get_most_desired_combination(samples_with_combination):
         number_of_combinations, support_size = (len(set(combination)), len(evidence))
         if support_size == 0:
             continue
-        if currently_chosen is None or (
-            best_number_of_combinations < number_of_combinations
-            and best_support_size > support_size
-        ):
+        if currently_chosen is None or
+            number_of_combinations > best_number_of_combinations or (
+                number_of_combinations == best_number_of_combinations
+                and support_size < best_support_size
+            ):
             currently_chosen = combination
             best_number_of_combinations, best_support_size = (
                 number_of_combinations,


### PR DESCRIPTION
I believe there's a logical error in `_get_most_desired_combination()`. The current condition requires both a larger `number_of_combinations` and a smaller `support_size` to replace the `currently_chosen`. However, this will lead to selecting the first combination that has max `number_of_combinations`. I'm pretty sure that's not what you want, because the ordering is simply based on the original insertion order, which is only based on the original label order.

I believe a better approach is to filter on combinations with the maximum size, and then among those, select the one with the minimum support.